### PR TITLE
fix: Add material-icons-core and -extended dependencies

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -44,6 +44,8 @@ kotlin {
             implementation(libs.voyager.navigator)
             implementation(libs.voyager.screenmodel)
             implementation(libs.voyager.transitions)
+            implementation("androidx.compose.material:material-icons-core")
+            implementation("androidx.compose.material:material-icons-extended")
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)


### PR DESCRIPTION
Added androidx.compose.material:material-icons-core and androidx.compose.material:material-icons-extended to commonMain dependencies to resolve 'Unresolved reference 'icons'' errors.

These dependencies were added without explicit versions to allow Gradle or the Compose Multiplatform plugin to attempt version alignment. Further adjustments to specify versions may be needed if this leads to new version conflicts (e.g., NoSuchMethodError).

This change is intended to make the Material Icons available to the common source set, particularly for targets like desktop.