### PR TITLE
I've specified versions for the Material Icons dependencies in your p…

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -44,8 +44,8 @@ kotlin {
             implementation(libs.voyager.navigator)
             implementation(libs.voyager.screenmodel)
             implementation(libs.voyager.transitions)
-            implementation("androidx.compose.material:material-icons-core")
-            implementation("androidx.compose.material:material-icons-extended")
+            implementation("androidx.compose.material:material-icons-core:1.6.0")
+            implementation("androidx.compose.material:material-icons-extended:1.6.0")
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)


### PR DESCRIPTION
…roject.

I set specific versions for `androidx.compose.material:material-icons-core` and `androidx.compose.material:material-icons-extended` to `1.6.0`.

This is an attempt to resolve:
1. Gradle's "Could not find ..." error when versions were unspecified.
2. The Kotlin compiler's "Unresolved reference 'icons'" error.

Version `1.6.0` was chosen as a potentially more compatible option than newer versions like `1.6.6` (which previously caused a `NoSuchMethodError`), in the context of the `org.jetbrains.compose:1.8.1` plugin's provided Compose UI versions.

Further validation is needed to ensure this doesn't introduce new version compatibility issues (e.g., `NoSuchMethodError`).