### PR TITLE
Refactor: Remove Voyager navigation library

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -40,9 +40,6 @@ kotlin {
             implementation("com.benasher44:uuid:0.8.2")
             implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.6.0")
             implementation(libs.kotlinx.serialization.json)
-            implementation(libs.voyager.navigator)
-            implementation(libs.voyager.screenmodel)
-            implementation(libs.voyager.transitions)
             implementation("androidx.compose.material:material-icons-core:1.6.0") {
                 exclude(group = "androidx.compose.ui", module = "ui")
                 exclude(group = "androidx.compose.ui", module = "ui-graphics")

--- a/composeApp/src/commonMain/kotlin/br/com/marconardes/storyflame/App.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/marconardes/storyflame/App.kt
@@ -1,11 +1,10 @@
 package br.com.marconardes.storyflame
 
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 // import br.com.marconardes.viewmodel.ProjectViewModel // ViewModel will be handled by Screens or ScreenModels
-import cafe.adriel.voyager.navigator.Navigator
-import cafe.adriel.voyager.transitions.SlideTransition
-import br.com.marconardes.storyflame.navigation.ProjectListScreen // Import your initial screen
+import br.com.marconardes.storyflame.navigation.ProjectListScreenView // Import initial screen view
 // Removed Preview import as it might conflict with Navigator, can be re-added if needed for specific screen previews
 // import org.jetbrains.compose.ui.tooling.preview.Preview
 
@@ -20,12 +19,8 @@ fun App() {
         // var editingChapter by remember { mutableStateOf<Chapter?>(null) }
         // var editChapterTitleInput by remember { mutableStateOf("") }
 
-        Navigator(screen = ProjectListScreen) { navigator ->
-            SlideTransition(navigator)
-            // If content doesn't show, try:
-            // SlideTransition(navigator) { screen ->
-            //     screen.Content()
-            // }
-        }
+        // TODO: Navigation has been removed. Implement a new navigation solution here.
+        // ProjectListScreenView() // Or some other initial screen Composable if it can be called directly
+        Text("Navigation has been removed. Implement a new navigation solution.")
     }
 }

--- a/composeApp/src/commonMain/kotlin/br/com/marconardes/storyflame/navigation/Screens.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/marconardes/storyflame/navigation/Screens.kt
@@ -23,78 +23,83 @@ import br.com.marconardes.storyflame.view.ProjectCreationView
 import br.com.marconardes.storyflame.view.ProjectListView
 // import br.com.marconardes.storyflame.view.RichTextEditorView // Used FQN below
 import br.com.marconardes.viewmodel.ProjectViewModel
-import cafe.adriel.voyager.core.model.rememberScreenModel // Added for ScreenModel
-import cafe.adriel.voyager.core.screen.Screen
-import cafe.adriel.voyager.navigator.LocalNavigator
-import cafe.adriel.voyager.navigator.currentOrThrow
+// import cafe.adriel.voyager.core.model.rememberScreenModel // Removed: Voyager
+// import cafe.adriel.voyager.core.screen.Screen // Removed: Voyager
+// import cafe.adriel.voyager.navigator.LocalNavigator // Removed: Voyager
+// import cafe.adriel.voyager.navigator.currentOrThrow // Removed: Voyager
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.debounce
 import androidx.compose.runtime.snapshotFlow // Added for Markdown auto-save
 // Keep br.com.marconardes.storyflame.view.EditChapterTitleDialog fully qualified in usage or add import here
 
-object ProjectListScreen : Screen {
-    @OptIn(ExperimentalMaterial3Api::class) // For Scaffold and TopAppBar
-    @Composable
-    override fun Content() {
-        val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() }
-        val projects by projectViewModel.projects.collectAsState()
-        val selectedProject by projectViewModel.selectedProject.collectAsState()
-        val navigator = LocalNavigator.currentOrThrow
+// Removed object ProjectListScreen as its Content is now ProjectListScreenView
+// object ProjectListScreen // Removed : Screen
+// No longer an override
 
-        Scaffold(
-            topBar = { TopAppBar(title = { Text("StoryFlame Projects") }) }
-        ) { paddingValues ->
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
-                    .padding(16.dp)
-            ) {
-                ProjectCreationView(
-                    projectViewModel = projectViewModel,
-                    modifier = Modifier.fillMaxWidth()
-                )
-                Spacer(modifier = Modifier.height(16.dp))
-                ProjectListView(
-                    projects = projects,
-                    selectedProject = selectedProject,
-                    onProjectSelected = { project ->
-                        navigator.push(ChapterListScreen(projectId = project.id))
-                    },
-                    modifier = Modifier.fillMaxWidth()
-                )
-            }
+@OptIn(ExperimentalMaterial3Api::class) // For Scaffold and TopAppBar
+@Composable
+fun ProjectListScreenView(projectViewModel: ProjectViewModel = ProjectViewModel() /* TODO: Review ViewModel instantiation */) {
+    val projects by projectViewModel.projects.collectAsState()
+    val selectedProject by projectViewModel.selectedProject.collectAsState()
+    // val navigator = LocalNavigator.currentOrThrow // Removed: Voyager
+
+    Scaffold(
+        topBar = { TopAppBar(title = { Text("StoryFlame Projects") }) }
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
+                .padding(16.dp)
+        ) {
+            ProjectCreationView(
+                projectViewModel = projectViewModel,
+                modifier = Modifier.fillMaxWidth()
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            ProjectListView(
+                projects = projects,
+                selectedProject = selectedProject,
+                onProjectSelected = { project ->
+                    // TODO: Navigate to ChapterListScreen(projectId = project.id)
+                    // navigator.push(ChapterListScreen(projectId = project.id)) // Removed: Voyager
+                },
+                modifier = Modifier.fillMaxWidth()
+            )
         }
     }
+    // Removed one extra closing brace that was here for ProjectListScreenView
 }
 
-data class ChapterActionChoiceScreen(val projectId: String, val chapterId: String) : Screen {
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    override fun Content() {
-        val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() }
-        val navigator = LocalNavigator.currentOrThrow
+data class ChapterActionChoiceScreenParams(val projectId: String, val chapterId: String) // Renamed from ChapterActionChoiceScreen, removed : Screen
+// No longer an override
 
-        val projects by projectViewModel.projects.collectAsState()
-        val currentProject = remember(projects, projectId) {
-            projects.find { it.id == projectId }
-        }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChapterActionChoiceScreenView(params: ChapterActionChoiceScreenParams, projectViewModel: ProjectViewModel = ProjectViewModel() /* TODO: Review ViewModel instantiation */) {
+    // val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() } // Removed: Voyager
+    // val navigator = LocalNavigator.currentOrThrow // Removed: Voyager
 
-        LaunchedEffect(currentProject) {
-            currentProject?.let { projectViewModel.selectProject(it) }
-        }
+    val projects by projectViewModel.projects.collectAsState()
+    val currentProject = remember(projects, params.projectId) { // Used params
+        projects.find { it.id == params.projectId }
+    }
 
-        val selectedProjectDetails by projectViewModel.selectedProject.collectAsState()
-        val currentChapter = remember(selectedProjectDetails, chapterId) {
-            selectedProjectDetails?.chapters?.find { it.id == chapterId }
-        }
+    LaunchedEffect(currentProject) {
+        currentProject?.let { projectViewModel.selectProject(it) }
+    }
 
-        Scaffold(
-            topBar = {
+    val selectedProjectDetails by projectViewModel.selectedProject.collectAsState()
+    val currentChapter = remember(selectedProjectDetails, params.chapterId) { // Used params
+        selectedProjectDetails?.chapters?.find { it.id == params.chapterId }
+    } // This curly brace is for 'remember'.
+
+    Scaffold( // This Scaffold should be outside the remember block's lambda.
+        topBar = {
                 TopAppBar(
                     title = { Text("Actions for: ${currentChapter?.title ?: "Chapter"}") },
                     navigationIcon = {
-                        TextButton(onClick = { navigator.pop() }) {
+                        TextButton(onClick = { /* TODO: Navigate back */ /* navigator.pop() */ }) { // Removed: Voyager
                             Text("Back") // Already "Back" from previous step, but ensuring it is.
                         }
                     }
@@ -114,14 +119,14 @@ data class ChapterActionChoiceScreen(val projectId: String, val chapterId: Strin
                     Text("Chapter: ${currentChapter.title}", style = MaterialTheme.typography.titleSmall) // Translated
                     Spacer(modifier = Modifier.height(32.dp))
                     Button(
-                        onClick = { navigator.replace(ChapterEditorScreen(projectId, chapterId, initialFocus = "summary")) },
+                        onClick = { /* TODO: Navigate to ChapterEditorScreen(params.projectId, params.chapterId, initialFocus = "summary") */ /* navigator.replace(ChapterEditorScreen(projectId, chapterId, initialFocus = "summary")) */ }, // Removed: Voyager
                         modifier = Modifier.fillMaxWidth(0.8f)
                     ) {
                         Text("Edit Summary") // Translated
                     }
                     Spacer(modifier = Modifier.height(16.dp))
                     Button(
-                        onClick = { navigator.replace(ChapterEditorScreen(projectId, chapterId, initialFocus = "content")) },
+                        onClick = { /* TODO: Navigate to ChapterEditorScreen(params.projectId, params.chapterId, initialFocus = "content") */ /* navigator.replace(ChapterEditorScreen(projectId, chapterId, initialFocus = "content")) */ }, // Removed: Voyager
                         modifier = Modifier.fillMaxWidth(0.8f)
                     ) {
                         Text("Edit Content (Markdown)") // Translated
@@ -131,38 +136,40 @@ data class ChapterActionChoiceScreen(val projectId: String, val chapterId: Strin
                 }
             }
         }
-    }
+    // Removed one extra closing brace that was here for ChapterActionChoiceScreenView
 }
 
-data class ChapterListScreen(val projectId: String) : Screen {
-    @OptIn(ExperimentalMaterial3Api::class) // For Scaffold, TopAppBar
-    @Composable
-    override fun Content() {
-        val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() }
-        val navigator = LocalNavigator.currentOrThrow
+data class ChapterListScreenParams(val projectId: String) // Renamed from ChapterListScreen, removed : Screen
+// No longer an override
 
-        var showEditChapterDialog by remember { mutableStateOf(false) }
-        var editingChapter by remember { mutableStateOf<Chapter?>(null) } // Corrected type
-        var editChapterTitleInput by remember { mutableStateOf("") }
+@OptIn(ExperimentalMaterial3Api::class) // For Scaffold, TopAppBar
+@Composable
+fun ChapterListScreenView(params: ChapterListScreenParams, projectViewModel: ProjectViewModel = ProjectViewModel() /* TODO: Review ViewModel instantiation */) {
+    // val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() } // Removed: Voyager
+    // val navigator = LocalNavigator.currentOrThrow // Removed: Voyager
 
-        val projects by projectViewModel.projects.collectAsState()
-        val currentProject = remember(projects, projectId) {
-            projects.find { it.id == projectId }
-        }
+    var showEditChapterDialog by remember { mutableStateOf(false) }
+    var editingChapter by remember { mutableStateOf<Chapter?>(null) } // Corrected type
+    var editChapterTitleInput by remember { mutableStateOf("") }
 
-        LaunchedEffect(currentProject) {
-            currentProject?.let { projectViewModel.selectProject(it) }
-        }
+    val projects by projectViewModel.projects.collectAsState()
+    val currentProject = remember(projects, params.projectId) { // Used params
+        projects.find { it.id == params.projectId }
+    }
 
-        val selectedProjectDetails by projectViewModel.selectedProject.collectAsState()
-        val chapters by projectViewModel.selectedProjectChapters.collectAsState()
+    LaunchedEffect(currentProject) {
+        currentProject?.let { projectViewModel.selectProject(it) }
+    }
 
-        Scaffold(
-            topBar = {
+    val selectedProjectDetails by projectViewModel.selectedProject.collectAsState()
+    val chapters by projectViewModel.selectedProjectChapters.collectAsState() // Corrected indentation
+
+    Scaffold(
+        topBar = {
                 TopAppBar(
                     title = { Text(selectedProjectDetails?.name ?: "Chapters") },
                     navigationIcon = {
-                        TextButton(onClick = { navigator.pop() }) {
+                        TextButton(onClick = { /* TODO: Navigate back */ /* navigator.pop() */ }) { // Removed: Voyager
                             Text("Back")
                         }
                     }
@@ -208,7 +215,8 @@ data class ChapterListScreen(val projectId: String) : Screen {
                                         .fillMaxWidth()
                                         .padding(vertical = 4.dp)
                                         .clickable {
-                                            navigator.push(ChapterActionChoiceScreen(projectId = projectId, chapterId = chapter.id))
+                                            // TODO: Navigate to ChapterActionChoiceScreen(projectId = params.projectId, chapterId = chapter.id)
+                                            // navigator.push(ChapterActionChoiceScreen(projectId = projectId, chapterId = chapter.id)) // Removed: Voyager
                                         },
                                     verticalAlignment = Alignment.CenterVertically
                                 ) {
@@ -266,39 +274,41 @@ data class ChapterListScreen(val projectId: String) : Screen {
                 }
             )
         }
-    }
+    // Removed one extra closing brace that was here for ChapterListScreenView
 }
 
-data class ChapterEditorScreen(val projectId: String, val chapterId: String, val initialFocus: String? = null) : Screen {
-    @OptIn(ExperimentalMaterial3Api::class)
-    @Composable
-    override fun Content() {
-        val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() }
-        val navigator = LocalNavigator.currentOrThrow
+data class ChapterEditorScreenParams(val projectId: String, val chapterId: String, val initialFocus: String? = null) // Renamed from ChapterEditorScreen, removed : Screen
+// No longer an override
 
-        var summaryInput by remember { mutableStateOf("") }
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ChapterEditorScreenView(params: ChapterEditorScreenParams, projectViewModel: ProjectViewModel = ProjectViewModel() /* TODO: Review ViewModel instantiation */) {
+    // val projectViewModel: ProjectViewModel = rememberScreenModel { ProjectViewModel() } // Removed: Voyager
+    // val navigator = LocalNavigator.currentOrThrow // Removed: Voyager
 
-        val projects by projectViewModel.projects.collectAsState()
-        val project = remember(projects, projectId) { projects.find { it.id == projectId } }
+    var summaryInput by remember { mutableStateOf("") }
 
-        LaunchedEffect(project) {
-            project?.let { projectViewModel.selectProject(it) }
-        }
+    val projects by projectViewModel.projects.collectAsState()
+    val project = remember(projects, params.projectId) { projects.find { it.id == params.projectId } } // Used params
 
-        val selectedProject by projectViewModel.selectedProject.collectAsState()
-        val chapter = remember(selectedProject, chapterId) {
-            selectedProject?.chapters?.find { it.id == chapterId }
-        }
+    LaunchedEffect(project) {
+        project?.let { projectViewModel.selectProject(it) }
+    }
 
-        LaunchedEffect(chapter) {
-            chapter?.let { summaryInput = it.summary }
-        }
+    val selectedProject by projectViewModel.selectedProject.collectAsState()
+    val chapter = remember(selectedProject, params.chapterId) { // Used params
+        selectedProject?.chapters?.find { it.id == params.chapterId }
+    }
 
-        var markdownInput by remember(chapter?.content) { mutableStateOf(chapter?.content ?: "") }
+    LaunchedEffect(chapter) {
+        chapter?.let { summaryInput = it.summary }
+    }
 
-        // Auto-save for Markdown editor
-        LaunchedEffect(Unit) { // Runs once, snapshotFlow handles recomposition
-            snapshotFlow { markdownInput }
+    var markdownInput by remember(chapter?.content) { mutableStateOf(chapter?.content ?: "") }
+
+    // Auto-save for Markdown editor
+    LaunchedEffect(Unit) { // Runs once, snapshotFlow handles recomposition
+        snapshotFlow { markdownInput }
                 .debounce(1000L) // 1-second debounce
                 .collectLatest { newContent ->
                     if (project != null && chapter != null) {
@@ -307,14 +317,14 @@ data class ChapterEditorScreen(val projectId: String, val chapterId: String, val
                         }
                     }
                 }
-        }
+    } // Closing brace for LaunchedEffect(Unit)
 
-        Scaffold(
-            topBar = {
+    Scaffold(
+        topBar = {
                 TopAppBar(
                     title = { Text(chapter?.title ?: "Edit Chapter") },
                     navigationIcon = {
-                        TextButton(onClick = { navigator.pop() }) {
+                        TextButton(onClick = { /* TODO: Navigate back */ /* navigator.pop() */ }) { // Removed: Voyager
                             Text("Back")
                         }
                     }
@@ -329,7 +339,7 @@ data class ChapterEditorScreen(val projectId: String, val chapterId: String, val
                         .padding(16.dp)
                     // .verticalScroll(rememberScrollState()) // Scroll will be handled by individual editors if needed or by weight
                 ) {
-                    when (initialFocus) {
+                    when (params.initialFocus) { // Used params
                         "summary" -> {
                             Text("Summary:", style = MaterialTheme.typography.titleMedium)
                             OutlinedTextField(
@@ -342,7 +352,8 @@ data class ChapterEditorScreen(val projectId: String, val chapterId: String, val
                             Button(
                                 onClick = {
                                     projectViewModel.updateChapterSummary(project, chapter.id, summaryInput)
-                                    // navigator.pop() // Optional: pop back after saving
+                                    // TODO: Navigate back (optional)
+                                    // navigator.pop() // Optional: pop back after saving // Removed: Voyager
                                 },
                                 modifier = Modifier.align(Alignment.End).padding(top = 8.dp)
                             ) {
@@ -377,5 +388,4 @@ data class ChapterEditorScreen(val projectId: String, val chapterId: String, val
                 }
             }
         }
-    }
-}
+} // Added missing closing brace for ChapterEditorScreenView

--- a/composeApp/src/commonMain/kotlin/br/com/marconardes/viewmodel/ProjectViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/br/com/marconardes/viewmodel/ProjectViewModel.kt
@@ -9,9 +9,9 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import cafe.adriel.voyager.core.model.ScreenModel
+// import cafe.adriel.voyager.core.model.ScreenModel // Removed: Voyager
 
-class ProjectViewModel : ScreenModel {
+class ProjectViewModel { // Removed : ScreenModel
     private val _projects = MutableStateFlow<List<Project>>(emptyList())
     val projects: StateFlow<List<Project>> = _projects.asStateFlow()
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,7 +17,6 @@ kotlin = "2.1.21"
 kotlinx-coroutines = "1.10.2"
 kotlinx-coroutines-test-version = "1.8.1-Beta" # kotlinx-coroutines-test version
 kotlinx-serialization = "1.6.3"
-voyager = "1.1.0-beta02"
 androidxComposeBom = "2024.04.00"
 
 [libraries]
@@ -35,9 +34,6 @@ androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle
 kotlinx-coroutinesSwing = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-swing", version.ref = "kotlinx-coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test-version" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinx-serialization" }
-voyager-navigator = { module = "cafe.adriel.voyager:voyager-navigator", version.ref = "voyager" }
-voyager-screenmodel = { module = "cafe.adriel.voyager:voyager-screenmodel", version.ref = "voyager" }
-voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", version.ref = "voyager" }
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
 
 [plugins]


### PR DESCRIPTION
This commit removes all dependencies and usages of the Voyager navigation library (cafe.adriel.voyager).

Key changes include:
- Removed Voyager dependencies from Gradle configuration (`libs.versions.toml` and `composeApp/build.gradle.kts`).
- Refactored `App.kt` to remove the Voyager `Navigator` and `SlideTransition` components. The app's entry point now contains a placeholder.
- Refactored `navigation/Screens.kt`:
    - All Voyager `Screen` objects and classes have been converted to regular Composable functions (e.g., `ProjectListScreenView`) and parameter data classes (e.g., `ChapterListScreenParams`).
    - Voyager-specific imports and navigator calls (`push`, `pop`, `replace`) have been removed and replaced with `// TODO:` comments indicating where navigation logic needs to be re-implemented.
    - `rememberScreenModel` usage was replaced with direct ViewModel instantiation, marked with a `// TODO:` for review.
- Removed `ScreenModel` inheritance from `ProjectViewModel`.

The project will require a new navigation solution to be implemented.

Note: During compilation checks, unrelated errors were observed in `composeApp/src/commonMain/kotlin/br/com/marconardes/storyflame/view/ChapterItemView.kt` concerning a rich text editor library. These issues are pre-existing or separate and were not addressed as part of this refactoring.