### PR TITLE
Refactor main screen to use a tabbed interface for better visibility

### DIFF
--- a/src/main/java/br/com/marconardes/storyflame/swing/Main.java
+++ b/src/main/java/br/com/marconardes/storyflame/swing/Main.java
@@ -7,6 +7,7 @@ import br.com.marconardes.storyflame.swing.view.ChapterEditorView;
 import br.com.marconardes.storyflame.swing.view.ChapterSectionView;
 import br.com.marconardes.storyflame.swing.view.ChapterSelectionListener;
 import br.com.marconardes.storyflame.swing.view.ProjectListView;
+import br.com.marconardes.storyflame.swing.view.CharacterListView; // Added import
 import br.com.marconardes.storyflame.swing.viewmodel.ProjectViewModel;
 
 import br.com.marconardes.storyflame.swing.util.ThemeManager;
@@ -31,15 +32,20 @@ public class Main implements ChapterEditorListener, ChapterSelectionListener {
     private ProjectListView projectListView;
     private ChapterSectionView chapterSectionView;
     private ChapterEditorView chapterEditorView; // New editor view
+    private CharacterListView characterListView; // Added field
     private TxtProjectExporter txtProjectExporter;
     private PdfProjectExporter pdfProjectExporter; // Added
 
-    private JPanel centerPanel; // Panel that will use CardLayout
-    private CardLayout cardLayout;
+    // private JPanel centerPanel; // Panel that will use CardLayout // Replaced by mainTabbedPane
+    // private CardLayout cardLayout; // Replaced by JTabbedPane logic
+    private JTabbedPane mainTabbedPane; // Added JTabbedPane field
+    private JPanel chaptersTabPanel; // Added panel for chapters tab
+    private CardLayout chaptersCardLayout; // Added CardLayout for chapters tab
     private JFrame frame; // Made JFrame a field
 
     private static final String CHAPTER_SECTION_PANEL = "CHAPTER_SECTION_PANEL";
     private static final String CHAPTER_EDITOR_PANEL = "CHAPTER_EDITOR_PANEL";
+    // private static final String CHARACTER_LIST_PANEL = "CHARACTER_LIST_PANEL"; // Reverted: Removed constant
 
 
     public Main() {
@@ -55,7 +61,7 @@ public class Main implements ChapterEditorListener, ChapterSelectionListener {
         frame.setMinimumSize(new Dimension(800, 600));
         frame.setLocationRelativeTo(null);
 
-        projectListView = new ProjectListView(projectViewModel);
+        projectListView = new ProjectListView(projectViewModel); // Reverted constructor call
 
         // Setup ChapterSectionView and set its listener
         chapterSectionView = new ChapterSectionView(projectViewModel);
@@ -66,17 +72,30 @@ public class Main implements ChapterEditorListener, ChapterSelectionListener {
         chapterEditorView = new ChapterEditorView(projectViewModel);
         chapterEditorView.setEditorListener(this);
 
-        // Setup center panel with CardLayout
-        cardLayout = new CardLayout();
-        centerPanel = new JPanel(cardLayout);
-        centerPanel.add(chapterSectionView, CHAPTER_SECTION_PANEL);
-        centerPanel.add(chapterEditorView, CHAPTER_EDITOR_PANEL);
+        // Instantiate CharacterListView
+        characterListView = new CharacterListView(projectViewModel);
+
+        // Setup JTabbedPane
+        mainTabbedPane = new JTabbedPane();
+
+        // Setup CardLayout for Chapters Tab
+        chaptersCardLayout = new CardLayout();
+        chaptersTabPanel = new JPanel(chaptersCardLayout);
+
+        // Add ChapterSectionView and ChapterEditorView to the chaptersTabPanel
+        // Ensure chapterSectionView and chapterEditorView are already instantiated
+        chaptersTabPanel.add(chapterSectionView, CHAPTER_SECTION_PANEL);
+        chaptersTabPanel.add(chapterEditorView, CHAPTER_EDITOR_PANEL);
+
+        // Add tabs to mainTabbedPane
+        mainTabbedPane.addTab("Capítulos", chaptersTabPanel);
+        mainTabbedPane.addTab("Personagens", characterListView); // Added CharacterListView tab
 
         JPanel mainPanel = new JPanel(new BorderLayout(5, 5));
         mainPanel.setBorder(BorderFactory.createEmptyBorder(5, 5, 5, 5));
 
         mainPanel.add(projectListView, BorderLayout.WEST);
-        mainPanel.add(centerPanel, BorderLayout.CENTER); // Add CardLayout panel to center
+        mainPanel.add(mainTabbedPane, BorderLayout.CENTER); // Add JTabbedPane to center
 
         frame.getContentPane().add(mainPanel);
         setupMenuBar(); // Call setupMenuBar
@@ -88,8 +107,8 @@ public class Main implements ChapterEditorListener, ChapterSelectionListener {
             }
         });
 
-        // Show ChapterSectionView initially
-        cardLayout.show(centerPanel, CHAPTER_SECTION_PANEL);
+        // Show ChapterSectionView initially within the chapters tab
+        chaptersCardLayout.show(chaptersTabPanel, CHAPTER_SECTION_PANEL);
     }
 
     // Implementation for ChapterSelectionListener (from ChapterSectionView)
@@ -98,7 +117,7 @@ public class Main implements ChapterEditorListener, ChapterSelectionListener {
         Project selectedProject = projectViewModel.getSelectedProject();
         if (selectedProject != null && chapter != null) {
             chapterEditorView.editChapter(selectedProject, chapter);
-            cardLayout.show(centerPanel, CHAPTER_EDITOR_PANEL);
+            chaptersCardLayout.show(chaptersTabPanel, CHAPTER_EDITOR_PANEL); // Use chaptersCardLayout
         }
     }
 
@@ -106,10 +125,18 @@ public class Main implements ChapterEditorListener, ChapterSelectionListener {
     @Override
     public void onEditorClosed(boolean saved) {
         // Regardless of save, switch back to chapter list view
-        cardLayout.show(centerPanel, CHAPTER_SECTION_PANEL);
+        chaptersCardLayout.show(chaptersTabPanel, CHAPTER_SECTION_PANEL); // Use chaptersCardLayout
         // If saved, ProjectViewModel would have already notified ChapterSectionView
         // to update itself if necessary.
     }
+
+    // public void showCharacterList() { // Reverted: Removed method
+    // ...
+    // }
+
+    // public void showChapterSection() { // Reverted: Removed method
+    // ...
+    // }
 
     private void setupMenuBar() {
         JMenuBar menuBar = new JMenuBar();

--- a/src/main/java/br/com/marconardes/storyflame/swing/view/ProjectListView.java
+++ b/src/main/java/br/com/marconardes/storyflame/swing/view/ProjectListView.java
@@ -34,7 +34,7 @@ public class ProjectListView extends JPanel {
     private JSpinner totalGoalSpinner;
     private JButton saveGoalsButton;
     private JPanel goalsPanel;
-    private JButton manageCharactersButton; // Added field for the button
+    // private JButton manageCharactersButton; // Removed field
 
     // UI Components for Progress Display
     private JLabel dailyProgressLabel;
@@ -42,7 +42,7 @@ public class ProjectListView extends JPanel {
     private JLabel totalProgressLabel;
     private JProgressBar totalProgressBar;
 
-    public ProjectListView(ProjectViewModel viewModel) {
+    public ProjectListView(ProjectViewModel viewModel) { // Reverted constructor
         this.viewModel = viewModel;
         setLayout(new BorderLayout(5,5)); // Added some gaps
         setPreferredSize(new Dimension(250, 0)); // Give it a preferred width
@@ -103,14 +103,14 @@ public class ProjectListView extends JPanel {
                 if (selectedProject != null) {
                     goalsPanel.setVisible(true);
                     saveGoalsButton.setEnabled(true);
-                    manageCharactersButton.setEnabled(true); // Enable here
+                    // manageCharactersButton.setEnabled(true); // Removed logic
                     dailyGoalSpinner.setValue(selectedProject.getDailyWritingGoal());
                     totalGoalSpinner.setValue(selectedProject.getTotalWritingGoal());
                     updateProgressDisplay(selectedProject); // Call to update progress display
                 } else {
                     goalsPanel.setVisible(false);
                     saveGoalsButton.setEnabled(false);
-                    manageCharactersButton.setEnabled(false); // Disable here
+                    // manageCharactersButton.setEnabled(false); // Removed logic
                     updateProgressDisplay(null); // Call to update progress display
                 }
             } else if (ProjectViewModel.PROJECTS_PROPERTY.equals(evt.getPropertyName())) {
@@ -125,14 +125,14 @@ public class ProjectListView extends JPanel {
                     if (currentSelectedInVM != null) { // If a project remains selected or is newly selected
                         goalsPanel.setVisible(true);
                         saveGoalsButton.setEnabled(true);
-                        manageCharactersButton.setEnabled(true); // Enable here
+                        // manageCharactersButton.setEnabled(true); // Removed logic
                         dailyGoalSpinner.setValue(currentSelectedInVM.getDailyWritingGoal());
                         totalGoalSpinner.setValue(currentSelectedInVM.getTotalWritingGoal());
                         updateProgressDisplay(currentSelectedInVM);
                     } else { // If no project is selected after list update
                         goalsPanel.setVisible(false);
                         saveGoalsButton.setEnabled(false);
-                        manageCharactersButton.setEnabled(false); // Disable here
+                        // manageCharactersButton.setEnabled(false); // Removed logic
                         updateProgressDisplay(null);
                     }
                 }
@@ -237,23 +237,18 @@ public class ProjectListView extends JPanel {
         JPanel projectActionsPanel = new JPanel(new FlowLayout(FlowLayout.CENTER));
         JButton addButton = new JButton("Add Project");
         JButton deleteButton = new JButton("Delete Project");
-        manageCharactersButton = new JButton("Manage Characters"); // Initialize field
+        // manageCharactersButton = new JButton("Manage Characters"); // Removed initialization
 
         addButton.addActionListener(this::addProject);
         deleteButton.addActionListener(this::deleteProject);
-        manageCharactersButton.addActionListener(e -> {
-            Project selectedProject = projectJList.getSelectedValue();
-            if (selectedProject != null) {
-                CharacterListView.showDialog((Frame) SwingUtilities.getWindowAncestor(this), viewModel, selectedProject);
-            } else {
-                JOptionPane.showMessageDialog(this, "Please select a project first.", "No Project Selected", JOptionPane.INFORMATION_MESSAGE);
-            }
-        });
+        // manageCharactersButton.addActionListener(e -> { // Removed ActionListener
+        // ...
+        // });
 
         projectActionsPanel.add(addButton);
         projectActionsPanel.add(deleteButton);
-        projectActionsPanel.add(manageCharactersButton); // Add button to panel
-        manageCharactersButton.setEnabled(false); // Initially disabled
+        // projectActionsPanel.add(manageCharactersButton); // Removed button from panel
+        // manageCharactersButton.setEnabled(false); // Removed logic
 
 
         // --- South Panel to hold Goals and Project Actions ---


### PR DESCRIPTION
This commit refactors the main application screen to use a JTabbedPane for displaying project-specific content, improving the visibility and accessibility of different elements like Chapters and Characters.

Key changes include:

1.  Reverted previous UI changes that attempted to manage view switching via buttons in ProjectListView and CardLayout in Main for characters.
2.  Modified `Main.java`:
    *   Replaced the central CardLayout panel with a `JTabbedPane`.
    *   Created a "Capítulos" (Chapters) tab. This tab now contains its own CardLayout to switch between `ChapterSectionView` (listing chapters) and `ChapterEditorView` (editing a chapter). Navigation logic was adapted accordingly.
    *   Created a "Personagens" (Characters) tab.
3.  Modified `CharacterListView.java`:
    *   Refactored to work as an embeddable panel within the "Personagens" tab, rather than a separate dialog.
    *   It now listens to `ProjectViewModel` for selected project changes to update its content.
    *   The standalone "Close" button and `showDialog` method were removed.
4.  Modified `ProjectListView.java`:
    *   Removed the "Manage Characters" button, as character access is now primarily through the "Personagens" tab.

This new tabbed layout provides a more organized and intuitive way for you to navigate and manage different aspects of your projects.